### PR TITLE
Use the cwd option to set the cwd

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,11 +4,7 @@ var execSync = require('child_process').execSync
 
 module.exports = function (cwd) {
 	var command = 'git log --pretty=oneline'
-	if (cwd) {
-		command = 'cd ' + cwd + ' && ' + command
-	}
-
-	var result = execSync(command).toString()
+	var result = execSync(command, { cwd: cwd }).toString()
 	return result
 		.split('\n')[0]
 		.split(' ')


### PR DESCRIPTION
`exec` and `execSync` allow to pass an options object in the second argument. We can use `cwd` to set the directory where to run the command.
